### PR TITLE
Change gnodev, gnokey and gnofaucets commands so they are compatible with the new cli…

### DIFF
--- a/docs/cli/gnofaucet.md
+++ b/docs/cli/gnofaucet.md
@@ -29,7 +29,7 @@ $ gnofaucet serve
 ### **Step 1. Create an account named `test1` with the test seed phrase below.**
 
 ```bash
-$ gnokey add test1 --recover
+$ gnokey add -recover test1 
 ```
 
 > **Test Seed Phrase:** source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast
@@ -37,7 +37,7 @@ $ gnokey add test1 --recover
 ### **Step 2. Run `gnofaucet`**
 
 ```bash
-$ gnofaucet serve test1 --chain-id dev --send 500000000ugnot
+$ gnofaucet serve -chain-id dev -send 500000000ugnot test1
 ```
 
 ### **Step 3. Receive GNOTs from the faucet**

--- a/docs/cli/gnokey.md
+++ b/docs/cli/gnokey.md
@@ -124,10 +124,10 @@ $ gnokey query {QUERY_PATH}
 | ------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
 | `auth/accounts/{ADDRESS}` | Returns information about an account.                              | `$ gnokey query auth/accounts/g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`                  |
 | `bank/balances/{ADDRESS}` | Returns balances of an account.                                    | `$ gnokey query bank/balances/g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`                  |
-| `vm/qfuncs`               | Returns public facing function signatures as JSON.                 | `$ gnokey query vm/qfuncs --data "gno.land/r/demo/boards"`                               |
-| `vm/qfile`                | Returns the file bytes, or list of files if directory.             | `$ gnokey query vm/qfile --data "gno.land/r/demo/boards"`                                |
-| `vm/qrender`              | Calls .Render(\<path>) in readonly mode.                           | `$ gnokey query vm/qrender --data "gno.land/r/demo/boards"`                              |
-| `vm/qeval`                | Evaluates any expression in readonly mode and returns the results. | `$ gnokey query vm/qeval --data "gno.land/r/demo/boards GetBoardIDFromName("my_board")"` |
+| `vm/qfuncs`               | Returns public facing function signatures as JSON.                 | `$ gnokey query vm/qfuncs -data "gno.land/r/demo/boards"`                                |
+| `vm/qfile`                | Returns the file bytes, or list of files if directory.             | `$ gnokey query vm/qfile -data "gno.land/r/demo/boards"`                                 |
+| `vm/qrender`              | Calls .Render(\<path>) in readonly mode.                           | `$ gnokey query vm/qrender -data "gno.land/r/demo/boards"`                               |
+| `vm/qeval`                | Evaluates any expression in readonly mode and returns the results. | `$ gnokey query vm/qeval -data "gno.land/r/demo/boards GetBoardIDFromName("my_board")"`  |
 | `vm/store`                | (not yet supported) Fetches items from the store.                  | -                                                                                        |
 | `vm/package`              | (not yet supported) Fetches a package's files.                     | -                                                                                        |
 
@@ -164,13 +164,14 @@ $ gnokey maketx {SUB_COMMAND} {ADDRESS or KeyName}
 This subcommand lets you upload a new package.
 
 ```bash
-$ gnokey maketx addpkg {ADDRESS} \
-    --gas-fee "1ugnot" \
-    --gas-wanted "5000000" \
-    --memo "" \
-    --pkgpath {Registered Realm path} \
-    --pkgdir {Package folder path} \
-    --deposit "" \
+$ gnokey maketx addpkg \
+    -gas-fee "1ugnot" \
+    -gas-wanted "5000000" \
+    -memo "" \
+    -pkgpath {Registered Realm path} \
+    -pkgdir {Package folder path} \
+    -deposit "" \
+    {ADDRESS} \
     > unsigned.tx
 ```
 
@@ -202,15 +203,16 @@ This subcommand lets you call a public function.
 
 ```bash
 # Register
-gnokey maketx call {ADDRESS} \
-    --gas-fee "1000000ugnot" \
-    --gas-wanted "2000000" \
-    --pkgpath "gno.land/r/demo/users" \
-    --send "200000000ugnot" \
-    --func "Register" \
-    --args "" \
-    --args {NAME} \
-    --args "" \
+gnokey maketx call \
+    -gas-fee "1000000ugnot" \
+    -gas-wanted "2000000" \
+    -pkgpath "gno.land/r/demo/users" \
+    -send "200000000ugnot" \
+    -func "Register" \
+    -args "" \
+    -args {NAME} \
+    -args "" \
+    {ADDRESS} \
     > unsigned.tx
 ```
 
@@ -242,12 +244,13 @@ gnokey maketx call {ADDRESS} \
 This subcommand lets you send a native currency to an address.
 
 ```bash
-gnokey maketx send {ADDRESS} \
-    --gas-fee "1ugnot" \
-    --gas-wanted "2000000" \
-    --memo "" \
-    --send {SEND_AMOUNT} \
-    --to {TO_ADDRESS} \
+gnokey maketx send \
+    -gas-fee "1ugnot" \
+    -gas-wanted "2000000" \
+    -memo "" \
+    -send {SEND_AMOUNT} \
+    -to {TO_ADDRESS} \
+    {ADDRESS} \
     > unsigned.tx
 ```
 

--- a/tutorials/cli/cli-examples.md
+++ b/tutorials/cli/cli-examples.md
@@ -7,7 +7,7 @@ You may create a new account or recover one using the seed phrase.
 ```bash
 $ gnokey generate # create a new seed phrase (mnemonic)
 
-$ gnokey add my-account --recover  # registers a key named ‘my-account’ with a seed phrase
+$ gnokey add -recover my-account # registers a key named ‘my-account’ with a seed phrase
 
 $ gnokey list # check the list of keys
 ```
@@ -17,7 +17,7 @@ $ gnokey list # check the list of keys
 ### **Step 1. Create an account named `test1` with the test seed phrase below.**
 
 ```bash
-$ gnokey add test1 --recover
+$ gnokey add -recover test1 
 ```
 
 > **Test Seed Phrase:** source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast
@@ -25,7 +25,7 @@ $ gnokey add test1 --recover
 ### **Step 2. Run the gnofaucet**
 
 ```bash
-$ gnofaucet serve test1 --chain-id dev --send 500000000ugnot
+$ gnofaucet serve -chain-id dev -send 500000000ugnot test1 
 ```
 
 ### **Step 3. Request for GNOT from the faucet**
@@ -39,16 +39,17 @@ $ curl --location --request POST 'http://localhost:5050' \
 ## Register As a User
 
 ```bash
-$ gnokey maketx call my-account \
-    --gas-fee "1000000ugnot" \
-    --gas-wanted "2000000" \
-    --pkgpath "gno.land/r/demo/users" \
-    --broadcast \
-    --send "200000000ugnot" \
-    --func "Register" \
-    --args "" \
-    --args "my_account" \ # (must be at least 6 characters, lowercase alphanumeric with underscore)
-    --args ""
+$ gnokey maketx call \
+    -gas-fee "1000000ugnot" \
+    -gas-wanted "2000000" \
+    -pkgpath "gno.land/r/demo/users" \
+    -broadcast \
+    -send "200000000ugnot" \
+    -func "Register" \
+    -args "" \
+    -args "my_account" \ # (must be at least 6 characters, lowercase alphanumeric with underscore)
+    -args "" \
+    my-account 
 
 # username: must be at least 6 characters, lowercase alphanumeric with underscore
 ```
@@ -65,7 +66,7 @@ $ gnokey query auth/accounts/{address}
 $ gnokey query bank/balances/{address}
 
 # Get /r/demo/boards user information
-$ gnokey query vm/qrender --data "gno.land/r/demo/users
+$ gnokey query vm/qrender -data "gno.land/r/demo/users
 my_account"
 ```
 
@@ -75,13 +76,14 @@ The following command will send 1,000,000 ugnot (= 1 GNOT) to the address specif
 
 ```bash
 # Creates and broadcast a token transfer transaction
-$ gnokey maketx send my-account \
-    --gas-fee "1ugnot" \
-    --gas-wanted "2000000" \
-    --memo "" \
-    --broadcast \
-    --send "1000000ugnot" \
-    --to "{address}"
+$ gnokey maketx send \
+    -gas-fee "1ugnot" \
+    -gas-wanted "2000000" \
+    -memo "" \
+    -broadcast \
+    -send "1000000ugnot" \
+    -to "{address}" \
+    my-account 
 ```
 
 ## Create a Board
@@ -90,12 +92,13 @@ You can create a board called `my_board` on the `gno.land/r/demo/boards` realm w
 
 ```bash
 # Calls the CreateBoard function of gno.land/r/demo/boards
-$ gnokey maketx call my-account \
-    --gas-fee "1000000ugnot" \
-    --gas-wanted "10000000" \
-    --broadcast \
-    --pkgpath "gno.land/r/demo/boards" \
-    --send "" \
-    --func "CreateBoard" \
-    --args "my_board"
+$ gnokey maketx call \
+    -gas-fee "1000000ugnot" \
+    -gas-wanted "10000000" \
+    -broadcast \
+    -pkgpath "gno.land/r/demo/boards" \
+    -send "" \
+    -func "CreateBoard" \
+    -args "my_board" \
+    my-account
 ```

--- a/tutorials/cli/gno-commands/gnokey.md
+++ b/tutorials/cli/gno-commands/gnokey.md
@@ -164,13 +164,14 @@ $ gnokey maketx {SUB_COMMAND} {ADDRESS or KeyName}
 This subcommand lets you upload a new package.
 
 ```bash
-$ gnokey maketx addpkg {ADDRESS} \
-    --gas-fee "1ugnot" \
-    --gas-wanted "5000000" \
-    --memo "" \
-    --pkgpath {Registered Realm path} \
-    --pkgdir {Package folder path} \
-    --deposit "" \
+$ gnokey maketx addpkg \
+    -gas-fee "1ugnot" \
+    -gas-wanted "5000000" \
+    -memo "" \
+    -pkgpath {Registered Realm path} \
+    -pkgdir {Package folder path} \
+    -deposit "" \
+    {ADDRESS} \
     > unsigned.tx
 ```
 
@@ -202,15 +203,16 @@ This subcommand lets you call a public function.
 
 ```bash
 # Register
-gnokey maketx call {ADDRESS} \
-    --gas-fee "1000000ugnot" \
-    --gas-wanted "2000000" \
-    --pkgpath "gno.land/r/demo/users" \
-    --send "200000000ugnot" \
-    --func "Register" \
-    --args "" \
-    --args {NAME} \
-    --args "" \
+gnokey maketx call \
+    -gas-fee "1000000ugnot" \
+    -gas-wanted "2000000" \
+    -pkgpath "gno.land/r/demo/users" \
+    -send "200000000ugnot" \
+    -func "Register" \
+    -args "" \
+    -args {NAME} \
+    -args "" \
+    {ADDRESS} \
     > unsigned.tx
 ```
 
@@ -242,12 +244,13 @@ gnokey maketx call {ADDRESS} \
 This subcommand lets you send a native currency to an address.
 
 ```bash
-gnokey maketx send {ADDRESS} \
-    --gas-fee "1ugnot" \
-    --gas-wanted "2000000" \
-    --memo "" \
-    --send {SEND_AMOUNT} \
-    --to {TO_ADDRESS} \
+gnokey maketx send \
+    -gas-fee "1ugnot" \
+    -gas-wanted "2000000" \
+    -memo "" \
+    -send {SEND_AMOUNT} \
+    -to {TO_ADDRESS} \
+    {ADDRESS} \
     > unsigned.tx
 ```
 

--- a/tutorials/interact-with-gnoland.md
+++ b/tutorials/interact-with-gnoland.md
@@ -13,7 +13,7 @@ In order to interact with Gnoland, you need an account that you will use to sign
 ```bash
 $ gnokey generate # create a new seed phrase (mnemonic)
 
-$ gnokey add {your_account_name} --recover  # registers a key with the name set as the value you put in {your_account_name} with a seed phrase
+$ gnokey add -recover {your_account_name}  # registers a key with the name set as the value you put in {your_account_name} with a seed phrase
 
 $ gnokey list # check the list of keys
 ```
@@ -21,18 +21,19 @@ $ gnokey list # check the list of keys
 ## Register As a User
 
 ```bash
-$ gnokey maketx call my-account \
-    --gas-fee "1000000ugnot" \
-    --gas-wanted "2000000" \
-    --pkgpath "gno.land/r/demo/users" \
-    --broadcast \
-    --send "200000000ugnot" \
-    --func "Register" \
-    --args "" \
-    --args "my_account" \ # (must be at least 6 characters, lowercase alphanumeric with underscore)
-    --args "" \
-    --chainid "test3" \
-    --remote "test3.gno.land:36657"
+$ gnokey maketx call \
+    -gas-fee "1000000ugnot" \
+    -gas-wanted "2000000" \
+    -pkgpath "gno.land/r/demo/users" \
+    -broadcast \
+    -send "200000000ugnot" \
+    -func "Register" \
+    -args "" \
+    -args "my_account" \ # (must be at least 6 characters, lowercase alphanumeric with underscore)
+    -args "" \
+    -chainid "test3" \
+    -remote "test3.gno.land:36657"
+    my-account 
 
 # username: must be at least 6 characters, lowercase alphanumeric with underscore
 ```
@@ -43,14 +44,14 @@ $ gnokey maketx call my-account \
 
 ```bash
 # Get account information
-$ gnokey query auth/accounts/{address} --remote "test3.gno.land:36657"
+$ gnokey query auth/accounts/{address} -remote "test3.gno.land:36657"
 
 # Get account balance
-$ gnokey query bank/balances/{address} --remote "test3.gno.land:36657"
+$ gnokey query bank/balances/{address} -remote "test3.gno.land:36657"
 
 # Get /r/demo/boards user information
-$ gnokey query vm/qrender --data "gno.land/r/demo/users
-my_account" --remote "test3.gno.land:36657"
+$ gnokey query vm/qrender -data "gno.land/r/demo/users
+my_account" -remote "test3.gno.land:36657"
 ```
 
 ## Send Tokens
@@ -59,15 +60,16 @@ The following command will send 1,000,000 ugnot (= 1 GNOT) to the address specif
 
 ```bash
 # Creates and broadcast a token transfer transaction
-$ gnokey maketx send my-account \
-    --gas-fee "1ugnot" \
-    --gas-wanted "2000000" \
-    --memo "" \
-    --broadcast \
-    --send "1000000ugnot" \
-    --to "{address}" \
-    --chainid "test3" \
-    --remote "test3.gno.land:36657"
+$ gnokey maketx \
+    -gas-fee "1ugnot" \
+    -gas-wanted "2000000" \
+    -memo "" \
+    -broadcast \
+    -send "1000000ugnot" \
+    -to "{address}" \
+    -chainid "test3" \
+    -remote "test3.gno.land:36657" \
+    send my-account 
 ```
 
 ## Create a Board
@@ -76,14 +78,15 @@ Try creating a board called `my_board` on the `gno.land/r/demo/boards` realm wit
 
 ```bash
 # Calls the CreateBoard function of gno.land/r/demo/boards
-$ gnokey maketx call my-account \
-    --gas-fee "1000000ugnot" \
-    --gas-wanted "10000000" \
-    --broadcast \
-    --pkgpath "gno.land/r/demo/boards" \
-    --send "" \
-    --func "CreateBoard" \
-    --args "my_board" \
-    --chainid "test3" \
-    --remote "test3.gno.land:36657"
+$ gnokey maketx call \
+    -gas-fee "1000000ugnot" \
+    -gas-wanted "10000000" \
+    -broadcast \
+    -pkgpath "gno.land/r/demo/boards" \
+    -send "" \
+    -func "CreateBoard" \
+    -args "my_board" \
+    -chainid "test3" \
+    -remote "test3.gno.land:36657" \
+    my-account 
 ```

--- a/tutorials/start-writing-a-realm.md
+++ b/tutorials/start-writing-a-realm.md
@@ -109,7 +109,7 @@ $ make gnokey
 Then, import the account with the following command (remember to use the seed phrase we shared above):
 
 ```bash
-$ gnokey add {account_name} --recover
+$ gnokey add -recover {account_name} 
 ```
 
 <figure><img src="../.gitbook/assets/12_gnokey_build_recover.png" alt=""><figcaption></figcaption></figure>
@@ -127,13 +127,14 @@ $ gnokey query "auth/accounts/{account_address}"
 Deploy the realm on your local network with the following command:
 
 ```bash
-gnokey maketx addpkg test \
---deposit "1ugnot" \
---gas-fee "1ugnot" \
---gas-wanted "5000000" \
---broadcast "true" \
---pkgdir "." \ 
---pkgpath "gno.land/r/demo/tutorial_test"
+gnokey maketx addpkg \
+-deposit "1ugnot" \
+-gas-fee "1ugnot" \
+-gas-wanted "5000000" \
+-broadcast "true" \
+-pkgdir "." \ 
+-pkgpath "gno.land/r/demo/tutorial_test"
+test
 ```
 
 > Note: `test` above is the account name we used for the recovered account, `--pkgdir` is where the contract to deploy is locally (in our case `~/demo` where the above code assumes the terminal is executing from), `--pkgpath` is the deploy to location.
@@ -170,13 +171,13 @@ Create a new account with the following command:
 
 ```bash
 $ gnokey add {account_name} # creates an address with a new seed phrase
-$ gnokey add {account_name} --recover --index {index} # creates an address using the existing seed phrase
+$ gnokey add -recover -index {index} {account_name} # creates an address using the existing seed phrase
 ```
 
 Then, check its balances on the testnet with the following command:
 
 ```bash
-$ gnokey query bank/balances/{your_address} --remote "http://test3.gno.land:36657"
+$ gnokey query bank/balances/{your_address} -remote "http://test3.gno.land:36657"
 ```
 
 <figure><img src="../.gitbook/assets/18_gnokey_new_addr_test3_balance.png" alt=""><figcaption></figcaption></figure>


### PR DESCRIPTION
Since the new cli https://github.com/gnolang/gno/pull/497 2 weeks ago, the tools like gnodev use single dash options (-foo) instead of --foo, and the address has to be put at the end. The pictures aren't changed however.