### PR TITLE
feat: add gno-js-client docs

### DIFF
--- a/docs/gno-js-client/README.md
+++ b/docs/gno-js-client/README.md
@@ -1,1 +1,7 @@
-# To be added
+# gno-js-client
+
+This section will provide an overview and basic features of `gno-js-client`.
+
+* [Getting Started](getting-started.md)
+* [Provider](provider/)
+* [Wallet](wallet/)

--- a/docs/gno-js-client/getting-started.md
+++ b/docs/gno-js-client/getting-started.md
@@ -1,0 +1,21 @@
+# Getting Started
+
+`@gnolang/gno-js-client` is a JavaScript/TypeScript client implementation for Gno chains. It is an extension of the
+[tm2-js-client](https://github.com/gnolang/tm2-js-client), but with Gno-specific functionality.
+
+## Key Features
+
+- Provides the ability to interact with Gno Realms / Packages
+- Easy interaction with VM-specific ABCI queries
+
+## Installation
+
+To install `@gnolang/gno-js-client`, use your preferred package manager:
+
+```bash
+yarn add @gnolang/gno-js-client
+```
+
+```bash
+npm install @gnolang/gno-js-client
+```

--- a/docs/gno-js-client/provider/README.md
+++ b/docs/gno-js-client/provider/README.md
@@ -1,0 +1,3 @@
+# Provider
+
+* [Gno Provider](gno-provider.md)

--- a/docs/gno-js-client/provider/gno-provider.md
+++ b/docs/gno-js-client/provider/gno-provider.md
@@ -1,0 +1,120 @@
+## Gno Provider
+
+The `Gno Provider` is an extension on the `tm2-js-client` `Provider`,
+outlined [here](../../tm2-js-client/provider/provider.md). Both JSON-RPC and WS providers are included with the package.
+
+## Realm Methods
+
+### getRenderOutput
+
+Executes the Render(<path>) method in read-only mode
+
+#### Parameters
+
+* `packagePath` **string** the gno package path
+* `path` **string** the render path
+* `height` **number** the height for querying.
+  If omitted, the latest height is used (optional, default `0`)
+
+Returns **Promise\<string>**
+
+#### Usage
+
+```ts
+await provider.getRenderOutput('gno.land/r/demo/demo_realm', '');
+// ## Hello World!
+```
+
+### getFunctionSignatures
+
+Fetches public facing function signatures
+
+#### Parameters
+
+* `packagePath` **string** the gno package path
+* `height` **number** the height for querying.
+  If omitted, the latest height is used (optional, default `0`)
+
+Returns **Promise\<FunctionSignature[]>**
+
+#### Usage
+
+```ts
+await provider.getFunctionSignatures('gno.land/r/demo/foo20');
+/*
+[
+  { FuncName: 'TotalSupply', Params: null, Results: [ [Object] ] },
+  {
+    FuncName: 'BalanceOf',
+    Params: [ [Object] ],
+    Results: [ [Object] ]
+  },
+  {
+    FuncName: 'Allowance',
+    Params: [ [Object], [Object] ],
+    Results: [ [Object] ]
+  },
+  {
+    FuncName: 'Transfer',
+    Params: [ [Object], [Object] ],
+    Results: null
+  },
+  {
+    FuncName: 'Approve',
+    Params: [ [Object], [Object] ],
+    Results: null
+  },
+  {
+    FuncName: 'TransferFrom',
+    Params: [ [Object], [Object], [Object] ],
+    Results: null
+  },
+  { FuncName: 'Faucet', Params: null, Results: null },
+  { FuncName: 'Mint', Params: [ [Object], [Object] ], Results: null },
+  { FuncName: 'Burn', Params: [ [Object], [Object] ], Results: null },
+  { FuncName: 'Render', Params: [ [Object] ], Results: [ [Object] ] }
+]
+ */
+```
+
+### evaluateExpression
+
+Evaluates any expression in readonly mode and returns the results
+
+#### Parameters
+
+* `packagePath` **string** the gno package path
+* `expression` **string** the expression to be evaluated
+* `height` **number** the height for querying.
+  If omitted, the latest height is used (optional, default `0`)
+
+Returns **Promise\<string>**
+
+#### Usage
+
+```ts
+await provider.evaluateExpression('gno.land/r/demo/foo20', 'TotalSupply()')
+// (10100000000 uint64)
+```
+
+### getFileContent
+
+Fetches the file content, or the list of files if the path is a directory
+
+#### Parameters
+
+* `packagePath` **string** the gno package path
+* `height` **number** the height for querying.
+  If omitted, the latest height is used (optional, default `0`)
+
+Returns **Promise\<string>**
+
+#### Usage
+
+```ts
+await provider.getFileContent('gno.land/r/demo/foo20', 'TotalSupply()')
+/*
+foo20.gno
+foo20_test.gno
+ */
+```

--- a/docs/gno-js-client/wallet/README.md
+++ b/docs/gno-js-client/wallet/README.md
@@ -1,0 +1,3 @@
+# Wallet
+
+* [Gno Wallet](gno-wallet.md)

--- a/docs/gno-js-client/wallet/gno-wallet.md
+++ b/docs/gno-js-client/wallet/gno-wallet.md
@@ -1,0 +1,74 @@
+## Gno Wallet
+
+The `Gno Wallet` is an extension on the `tm2-js-client` `Wallet`, outlined [here](../../tm2-js-client/wallet/wallet.md).
+
+## Account Methods
+
+### transferFunds
+
+Initiates a native currency transfer transaction between accounts
+
+#### Parameters
+
+* `to` **string** the bech32 address of the receiver
+* `funds` **Map\<string, number>** the denomination -> value map for funds
+* `fee` **TxFee** the custom transaction fee, if any
+
+Returns **Promise\<string>**
+
+#### Usage
+
+```ts
+let fundsMap = new Map<string, number>([
+    ["ugnot", 10],
+]);
+
+await wallet.transferFunds('g1flk9z2qmkgqeyrl654r3639rzgz7xczdfwwqw7', fundsMap);
+// returns the transaction hash
+```
+
+### callMethod
+
+Invokes the specified method on a GNO contract
+
+#### Parameters
+
+* `path` **string** the gno package / realm path
+* `method` **string** the method name
+* `args` **string[]** the method arguments, if any
+* `funds` **Map\<string, number>** the denomination -> value map for funds
+* `fee` **TxFee** the custom transaction fee, if any
+
+Returns **Promise\<string>**
+
+#### Usage
+
+```ts
+let fundsMap = new Map<string, number>([
+    ["ugnot", 10],
+]);
+
+await wallet.callMethod('gno.land/r/demo/foo20', 'TotalBalance', []);
+// returns the transaction hash
+```
+
+### deployPackage
+
+Deploys the specified package / realm
+
+#### Parameters
+
+* `gnoPackage` **MemPackage** the package / realm to be deployed
+* `funds` **Map\<string, number>** the denomination -> value map for funds
+* `fee` **TxFee** the custom transaction fee, if any
+
+Returns **Promise\<string>**
+
+#### Usage
+
+```ts
+const memPackage: MemPackage = // ...
+
+    await wallet.deployPackage(memPackage);
+// returns the transaction hash
+```

--- a/docs/tm2-js-client/README.md
+++ b/docs/tm2-js-client/README.md
@@ -1,6 +1,6 @@
 # tm2-js-client
 
-This section will provide an overview and basic features of tm2-js-client.
+This section will provide an overview and basic features of `tm2-js-client`.
 
 * [Getting Started](getting-started.md)
 * [Provider](provider/)

--- a/docs/tm2-js-client/provider/README.md
+++ b/docs/tm2-js-client/provider/README.md
@@ -1,6 +1,6 @@
 # Provider
 
-* [json-rpc-provider](json-rpc-provider.md)
 * [Provider](provider.md)
+* [JSON-RPC Provider](json-rpc-provider.md)
+* [WS Provider](ws-provider.md)
 * [Utility](utility.md)
-* [Ws-provider](ws-provider.md)

--- a/docs/tm2-js-client/provider/provider.md
+++ b/docs/tm2-js-client/provider/provider.md
@@ -11,8 +11,6 @@ Currently, the `tm2-js-client` package provides support for two Provider impleme
 - [WS Provider](ws-provider.md): executes each call through an active WebSocket connection, which requires closing when
   not needed anymore.
 
-Read-only abstraction for accessing blockchain data
-
 ## Account Methods
 
 ### getBalance


### PR DESCRIPTION
## Description

This PR populates the documentation section on [gno-js-client](https://github.com/gnolang/gno-js-client)